### PR TITLE
fix(logstash-reporter): send data w/ `@timestamp`

### DIFF
--- a/lib/reporters/logstash.js
+++ b/lib/reporters/logstash.js
@@ -1,4 +1,3 @@
-var async = require('async');
 var Logstash = require('logstash-client');
 
 function LogstashReporter (options) {
@@ -19,18 +18,15 @@ function LogstashReporter (options) {
     type: this.type,
     host: this.host,
     port: this.port,
-    format: function (line) {
-      line['@timestamp'] = new Date();
-      return JSON.stringify(line) + '\n';
+    format: function (data) {
+      data['@timestamp'] = new Date();
+      return JSON.stringify(data) + '\n';
     }
   });
 }
 
 LogstashReporter.prototype.send = function (data, callback) {
-  var _logstashClient = this.logstashClient;
-  async.each(data, function (line, cb) {
-    _logstashClient.send(line, cb);
-  }, callback);
+  this.logstashClient.send(data, callback);
 };
 
 function create(options) {

--- a/lib/reporters/logstash.spec.js
+++ b/lib/reporters/logstash.spec.js
@@ -54,15 +54,16 @@ describe('The Logstash reporter module', function () {
 
     var logstashReporter = LogstashReporter.create(options);
 
-    var data = [{
-      trace: 'very data'
-    }];
+    var data = {
+      sampleRate: 1,
+      samples:['a', 'b', 'c']
+    };
 
     sinon.stub(logstashReporter.logstashClient.transport, 'send', function (raw, cb) {
       expect(typeof raw).to.be.eq('string');
       var json = JSON.parse(raw);
+      expect(json.samples.length).to.be.eq(3);
       expect(json['@timestamp']).to.be.ok;
-      expect(json.trace).to.be.eq('very data');
       cb(null);
     });
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "url": "https://github.com/RisingStack/trace-nodejs/issues"
   },
   "dependencies": {
-    "async": "^1.4.0",
     "continuation-local-storage": "^3.1.4",
     "debug": "^2.1.3",
     "lodash": "^3.10.0",


### PR DESCRIPTION
Reduce complexity of logstash reporter's `send` function
Remove async
Update test