### PR TITLE
[WIP] Change stream wrap to http.Server

### DIFF
--- a/lib/providers/httpTransaction/wraps/index.js
+++ b/lib/providers/httpTransaction/wraps/index.js
@@ -1,5 +1,4 @@
 var http = require('http');
-var stream = require('stream');
 
 var getNamespace = require('continuation-local-storage').getNamespace;
 var Shimmer = require('./shimmer');
@@ -25,7 +24,7 @@ function instrument (collector, config) {
     return require('./process._fatalException.js')(original, collector, config);
   });
 
-  getNamespace('trace').bindEmitter(stream.prototype);
+  getNamespace('trace').bindEmitter(http.Server.prototype);
 }
 
 function uninstrument () {


### PR DESCRIPTION
Originally the CLS wrap was bound to stream prototype for universal usage, but
it conflicts with some libraries also using the stream module.