### PR TITLE
userSend: change user sent api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,9 +28,9 @@ function Trace () {
   })
 }
 
-Trace.prototype.report = function (data) {
-  debug('trace.report', data)
-  this.events.emit('user_sent_event', data)
+Trace.prototype.report = function (name, data) {
+  debug('trace.report', name, data)
+  this.events.emit(this.events.USER_SENT_EVENT, name, data)
 }
 
 Trace.prototype.getTransactionId = function (getTransactionId) {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -24,7 +24,20 @@ describe('The Trace module', function () {
     expect(trace.getTransactionId).to.be.ok
   })
 
-  it('reports')
+  it('reports', function () {
+    var userSentEvent = 'user_sent_event'
+    var name = 'name'
+    var data = {
+      key: 'value'
+    }
+    trace.events = {
+      emit: this.sandbox.spy(),
+      USER_SENT_EVENT: userSentEvent
+    }
+    trace.report(name, data)
+    expect(trace.events.emit).to.have.been.calledOnce
+    expect(trace.events.emit).to.have.been.calledWith(userSentEvent, name, data)
+  })
 
   it('returns the current transaction id', function () {
     expect(trace.getTransactionId()).to.eql(transactionId)

--- a/lib/providers/httpTransaction/index.js
+++ b/lib/providers/httpTransaction/index.js
@@ -216,28 +216,27 @@ HttpTransaction.prototype.onServerReceive = function (data) {
   })
 }
 
-HttpTransaction.prototype.report = function (data) {
+HttpTransaction.prototype.report = function (name, userData) {
   var session = getNamespace('trace')
   var traceId = session.get('request-id')
   var spanId = session.get('span-id')
 
-  if (typeof data !== 'object') {
+  if (typeof userData !== 'object') {
     console.error(format('%s TRACE: report parameter must be an object', new Date()))
     return new Error('report parameter must be an object')
   }
-
-  // do not modify user's data
-  var dataWithId = defaults({}, data, {
+  var trace = this._initTrace({
     id: traceId
   })
-
-  var trace = this._initTrace(dataWithId)
 
   var dataToSend = {
     id: spanId,
     time: microtime.now(),
-    data: data,
-    type: 'us'
+    type: 'us',
+    data: {
+      name: name,
+      payload: userData
+    }
   }
 
   trace.events.push(dataToSend)

--- a/lib/providers/httpTransaction/index.spec.js
+++ b/lib/providers/httpTransaction/index.spec.js
@@ -29,6 +29,7 @@ describe('The HttpTransaction module', function () {
     var data = {
       foo: 'bar'
     }
+    var name = 'name'
 
     var createNamespace = require('continuation-local-storage').createNamespace
     var session = createNamespace('trace')
@@ -50,7 +51,7 @@ describe('The HttpTransaction module', function () {
       session.set('request-id', traceId)
       session.set('span-id', spanId)
 
-      err = httpTransaction.report(data)
+      err = httpTransaction.report(name, data)
     })
 
     // get result with next partial
@@ -71,7 +72,10 @@ describe('The HttpTransaction module', function () {
           id: '456',
           time: httpTransaction.partials[traceId].events[0].time,
           type: 'us',
-          data: data
+          data: {
+            name: name,
+            payload: data
+          }
         }
       ]
     })


### PR DESCRIPTION
previously users were able to send an object to the api
along with their messages, now they have to provide a name
for their message object