### PR TITLE
fix(test): Use manually started timers

### DIFF
--- a/lib/agent/control/control.js
+++ b/lib/agent/control/control.js
@@ -1,7 +1,11 @@
 var debug = require('debug')('risingstack/trace')
 
+var Timer = require('../timer')
+
 function Control (options) {
   var _this = this
+  this.name = 'Control'
+
   this.collectorApi = options.collectorApi
   this.controlBus = options.controlBus
   this.config = options.config
@@ -10,7 +14,7 @@ function Control (options) {
 
   this.getUpdates()
 
-  this.interval = setInterval(function () {
+  this.timer = new Timer(function () {
     _this.getUpdates()
   }, this.updateInterval)
 }

--- a/lib/agent/control/control.spec.js
+++ b/lib/agent/control/control.spec.js
@@ -1,9 +1,10 @@
 var expect = require('chai').expect
 
 var Control = require('./')
+var Timer = require('../timer')
 
 describe('The Control module', function () {
-  it('interprets commands', function () {
+  it('gets memory-heapdump', function () {
     var collectorApi = {
       getUpdates: function (options, cb) {
         cb(null, {
@@ -16,9 +17,7 @@ describe('The Control module', function () {
     }
 
     var controlBus = {
-      on: function () {
-
-      },
+      on: function () {},
       emit: this.sandbox.spy()
     }
 
@@ -31,5 +30,17 @@ describe('The Control module', function () {
     })
     profiler.getUpdates()
     expect(controlBus.emit).to.be.calledWith('memory-heapdump', undefined)
+  })
+  it('should have a timer', function () {
+    var collectorApi = {
+      getUpdates: function () { }
+    }
+    var profiler = Control.create({
+      collectorApi: collectorApi,
+      config: {
+        updateInterval: 1
+      }
+    })
+    expect(profiler.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/healthcheck/index.js
+++ b/lib/agent/healthcheck/index.js
@@ -1,10 +1,13 @@
-function Healthcheck (options) {
-  var _this = this
+var Timer = require('../timer')
 
+function Healthcheck (options) {
+  this.name = 'Healthcheck'
+  var _this = this
   this.collectorApi = options.collectorApi
   this.config = options.config
   this.healthcheckInterval = this.config.healthcheckInterval
-  this.interval = setInterval(function () {
+
+  this.timer = new Timer(function () {
     _this.ping()
   }, this.healthcheckInterval)
 }

--- a/lib/agent/healthcheck/index.spec.js
+++ b/lib/agent/healthcheck/index.spec.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
 
 var Healthcheck = require('./')
+var Timer = require('../timer')
 
 describe('The Healthcheck module', function () {
   it('pings the collector', function () {
@@ -18,5 +19,19 @@ describe('The Healthcheck module', function () {
     healthcheck.ping()
 
     expect(collectorApi.ping).to.be.called
+  })
+
+  it('should have a timer', function () {
+    var collectorApi = {
+      ping: this.sandbox.spy()
+    }
+
+    var healthcheck = Healthcheck.create({
+      collectorApi: collectorApi,
+      config: {
+        healthcheckInterval: 1
+      }
+    })
+    expect(healthcheck.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/index.js
+++ b/lib/agent/index.js
@@ -15,6 +15,8 @@ var ReservoirSampler = require('./reservoir_sampler')
 var Profiler = require('./profiler')
 var Control = require('./control')
 
+var Timer = require('./timer')
+
 var controlBus = new EventEmitter()
 
 var REQUEST_ID = 'request-id'
@@ -28,13 +30,6 @@ function Agent (options) {
   this.collectorApi = CollectorApi.create(options.config)
   // config
   this.config = options.config
-  this.collectInterval = this.config.collectInterval
-
-  this.totalRequestCount = 0
-  this.mustCollectCount = 0
-
-  // init required variables
-  this.partials = {}
 
   this.apmMetrics = Metrics.apm.create({
     collectorApi: this.collectorApi,
@@ -79,29 +74,66 @@ function Agent (options) {
     controlBus: controlBus
   })
 
+  // TODO: The Tracer agent, to be extracted
+  this.name = 'Tracer'
+
+  this.collectInterval = this.config.collectInterval
+
+  this.totalRequestCount = 0
+  this.mustCollectCount = 0
+
+  // init required variables
+  this.partials = {}
+
+  this.reservoirSampler = new ReservoirSampler(MUST_COLLECT_LIMIT)
+
+  this.timer = new Timer(function () {
+    _this._send()
+  }, this.collectInterval)
+
+  this.tracer = this
+
+  //
+
+  this.agents = [
+    this.tracer,
+    this.apmMetrics,
+    this.healthcheck,
+    this.rpmMetrics,
+    this.externalEdgeMetrics,
+    this.incomingEdgeMetrics,
+    this.memoryProfiler,
+    this.cpuProfiler,
+    this.control
+  ]
+}
+
+Agent.prototype.start = function () {
+  var _this = this
   this.collectorApi.getService(function (err, serviceKey) {
     if (err) {
       return debug(err.message)
     }
     debug('Agent serviceKey is set to: ', serviceKey)
     _this.serviceKey = serviceKey
-    _this.start()
+    _this._startAll()
   })
-
-  this.reservoirSampler = new ReservoirSampler(MUST_COLLECT_LIMIT)
 }
 
-Agent.prototype.start = function () {
-  var _this = this
-  debug('Agent started collecting')
-  this.transactionIntervalId = setInterval(function () {
-    _this._send()
-  }, this.collectInterval)
+Agent.prototype._startAll = function () {
+  this.agents.forEach(function (agent) {
+    debug(agent.name + ' started')
+    if (agent.timer != null) {
+      agent.timer.start()
+    }
+  })
 }
 
-Agent.prototype.stop = function () {
-  debug('Agent stopped collecting')
-  clearInterval(this.transactionIntervalId)
+Agent.prototype._stopAll = function () {
+  this.agents.forEach(function (agent) {
+    debug(agent.name + ' stopped')
+    agent.timer.end()
+  })
 }
 
 Agent.prototype.getServiceKey = function () {

--- a/lib/agent/metrics/apm/index.js
+++ b/lib/agent/metrics/apm/index.js
@@ -1,10 +1,12 @@
 var os = require('os')
 var gc = require('../../../optionalDependencies/gc-stats')()
 var eventLoopStats = require('../../../optionalDependencies/event-loop-stats')
+var Timer = require('../../timer')
 
 var BYTES_TO_MEGABYTES = 1024 * 1024
 
 function ApmMetrics (options) {
+  this.name = 'Metrics/APM'
   var _this = this
   this.cpuCount = os.cpus().length
   this.pid = process.pid
@@ -18,9 +20,6 @@ function ApmMetrics (options) {
     scavenge: 0,
     marksweep: 0
   }
-  this.interval = setInterval(function () {
-    _this.sendMetrics()
-  }, this.collectInterval)
 
   gc.on('stats', function (stats) {
     // time is in nanoseconds
@@ -39,6 +38,10 @@ function ApmMetrics (options) {
         break
     }
   })
+
+  this.timer = new Timer(function () {
+    _this.sendMetrics()
+  }, this.collectInterval)
 }
 
 ApmMetrics.prototype.sendMetrics = function () {

--- a/lib/agent/metrics/apm/index.spec.js
+++ b/lib/agent/metrics/apm/index.spec.js
@@ -3,6 +3,7 @@ var os = require('os')
 var eventLoopStats = require('event-loop-stats')
 
 var ApmMetrics = require('./')
+var Timer = require('../../timer')
 
 describe('The ApmMetrics module', function () {
   it('sends metrics', function () {
@@ -99,5 +100,21 @@ describe('The ApmMetrics module', function () {
     expect(apmMetrics.getLoad()).to.eql({
       utilization: null
     })
+  })
+
+  it('should have a timer', function () {
+    var collectorApi = {
+      sendApmMetrics: this.sandbox.spy()
+    }
+
+    var apmMetrics = ApmMetrics.create({
+      collectorApi: collectorApi,
+      config: {
+        collectInterval: 1,
+        isRunningInVm: true
+      }
+    })
+
+    expect(apmMetrics.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/metrics/externalEdge/index.js
+++ b/lib/agent/metrics/externalEdge/index.js
@@ -1,8 +1,10 @@
 var debug = require('debug')('risingstack/trace')
 var flatMap = require('lodash.flatmap')
 var consts = require('../../../consts')
+var Timer = require('../../timer')
 
 function ExternalEdgeMetrics (options) {
+  this.name = 'Metrics/ExternalEdge'
   var _this = this
   this.collectorApi = options.collectorApi
   this.config = options.config
@@ -11,7 +13,7 @@ function ExternalEdgeMetrics (options) {
   // metrics
   this.metrics = {}
 
-  this.interval = setInterval(function () {
+  this.timer = new Timer(function () {
     _this.sendMetrics()
   }, this.collectInterval)
 }

--- a/lib/agent/metrics/externalEdge/index.spec.js
+++ b/lib/agent/metrics/externalEdge/index.spec.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
 
 var ExternalEdgeMetrics = require('./')
+var Timer = require('../../timer')
 
 describe('The ExternalEdgeMetrics module', function () {
   it('discards undefined responseTime values', function () {
@@ -111,5 +112,19 @@ describe('The ExternalEdgeMetrics module', function () {
       timestamp: ISOString,
       data: expectedHostMetrics
     })
+  })
+
+  it('should have a timer', function () {
+    var collectorApi = {
+      sendExternalEdgeMetrics: this.sandbox.spy()
+    }
+    var edgeMetrics = ExternalEdgeMetrics.create({
+      collectorApi: collectorApi,
+      config: {
+        collectInterval: 1
+      }
+    })
+
+    expect(edgeMetrics.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/metrics/incomingEdge/index.js
+++ b/lib/agent/metrics/incomingEdge/index.js
@@ -1,6 +1,8 @@
 var flatMap = require('lodash.flatmap')
+var Timer = require('../../timer')
 
 function IncomingEdgeMetrics (options) {
+  this.name = 'Metrics/IncomingEdge'
   var _this = this
   this.collectorApi = options.collectorApi
   this.config = options.config
@@ -9,7 +11,7 @@ function IncomingEdgeMetrics (options) {
   // metrics
   this.metrics = {}
 
-  this.interval = setInterval(function () {
+  this.timer = new Timer(function () {
     _this.sendMetrics()
   }, this.collectInterval)
 }

--- a/lib/agent/metrics/incomingEdge/index.spec.js
+++ b/lib/agent/metrics/incomingEdge/index.spec.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect
 
 var EdgeMetrics = require('./')
-
+var Timer = require('../../timer')
 describe('The IncomingEdgeMetrics module', function () {
   it('discards negative transportDelays', function () {
     var ISOString = 'date-string'
@@ -159,5 +159,19 @@ describe('The IncomingEdgeMetrics module', function () {
       },
       protocol: 'http'
     }])
+  })
+  it('should have a timer', function () {
+    var collectorApi = {
+      sendIncomingEdgeMetrics: this.sandbox.spy()
+    }
+
+    var edgeMetrics = EdgeMetrics.create({
+      collectorApi: collectorApi,
+      config: {
+        collectInterval: 1
+      }
+    })
+
+    expect(edgeMetrics.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/metrics/rpm/index.js
+++ b/lib/agent/metrics/rpm/index.js
@@ -1,4 +1,7 @@
+var Timer = require('../../timer')
+
 function RpmMetrics (options) {
+  this.name = 'Metrics/RPM'
   var _this = this
   this.collectorApi = options.collectorApi
   this.config = options.config
@@ -9,7 +12,7 @@ function RpmMetrics (options) {
   this.responseTimes = []
   this.totalRequestCount = 0
 
-  this.interval = setInterval(function () {
+  this.timer = new Timer(function () {
     _this.sendMetrics()
   }, this.collectInterval)
 }

--- a/lib/agent/metrics/rpm/index.spec.js
+++ b/lib/agent/metrics/rpm/index.spec.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
 
 var RpmMetrics = require('./')
+var Timer = require('../../timer')
 
 describe('The RpmMetrics module', function () {
   it('sends metrics', function () {
@@ -53,5 +54,19 @@ describe('The RpmMetrics module', function () {
       ninetyFive: 11,
       timestamp: ISOString
     })
+  })
+  it('should have a timer', function () {
+    var collectorApi = {
+      sendRpmMetrics: this.sandbox.spy()
+    }
+
+    var rpmMetrics = RpmMetrics.create({
+      collectorApi: collectorApi,
+      config: {
+        collectInterval: 1
+      }
+    })
+
+    expect(rpmMetrics.timer).to.be.instanceof(Timer)
   })
 })

--- a/lib/agent/profiler/cpu/index.js
+++ b/lib/agent/profiler/cpu/index.js
@@ -3,6 +3,7 @@ var debug = require('debug')('risingstack/trace')
 var v8profiler = require('../../../optionalDependencies/v8-profiler')
 
 function CpuProfiler (options) {
+  this.name = 'Profiler/CPU'
   var _this = this
   this.collectorApi = options.collectorApi
   this.controlBus = options.controlBus

--- a/lib/agent/profiler/memory/index.js
+++ b/lib/agent/profiler/memory/index.js
@@ -4,6 +4,7 @@ var v8profiler = require('../../../optionalDependencies/v8-profiler')
 
 function MemoryProfiler (options) {
   var _this = this
+  this.name = 'Profiler/Memory'
   this.collectorApi = options.collectorApi
   this.controlBus = options.controlBus
 

--- a/lib/agent/timer.js
+++ b/lib/agent/timer.js
@@ -1,0 +1,35 @@
+'use strict'
+
+function Timer (task, interval) {
+  this._handle = undefined
+  this.task = task
+  this._interval = interval
+}
+
+Timer.prototype.start = function (interval) {
+  if (interval != null) {
+    this._interval = interval
+  }
+  if (this._handle == null) {
+    this._handle = setInterval(this.task, this._interval)
+  }
+}
+
+Timer.prototype.end = function () {
+  if (this._handle != null) {
+    clearInterval(this._handle)
+    this._handle = undefined
+  }
+}
+
+Timer.prototype.restart = function (interval) {
+  if (interval != null) {
+    this._interval = interval
+  }
+  if (this._handle != null) {
+    clearInterval(this._handle)
+    this._handle = setInterval(this.task, this._interval)
+  }
+}
+
+module.exports = Timer

--- a/lib/agent/timer.spec.js
+++ b/lib/agent/timer.spec.js
@@ -1,0 +1,83 @@
+var Timer = require('./timer')
+var expect = require('chai').expect
+
+describe('Timer', function () {
+  it('should be constructible without arguments', function () {
+    var timer = new Timer()
+    expect(timer.task).to.be.undefined
+  })
+  it('should be constructible with a task', function () {
+    var task = function () {}
+    var timer = new Timer(task)
+    expect(timer.task).to.eql(task)
+  })
+  it('should be ticking with argument given the constructor', function () {
+    var task = this.sandbox.spy()
+    var timer = new Timer(task, 1)
+
+    var clock = this.sandbox.useFakeTimers()
+    timer.start()
+    clock.tick(3)
+    timer.end()
+    clock.restore()
+    expect(task).to.have.been.calledThrice
+  })
+  it('should be ticking with the argument given to the start method', function () {
+    var task = this.sandbox.spy()
+    var timer = new Timer(task)
+
+    var clock = this.sandbox.useFakeTimers()
+    timer.start(1)
+    clock.tick(3)
+    timer.end()
+    clock.restore()
+    expect(task).to.have.been.calledThrice
+  })
+  it('shouldn\'t be restartable with start', function () {
+    var task = this.sandbox.spy()
+    var anotherTask = this.sandbox.spy()
+    var timer = new Timer()
+    var clock = this.sandbox.useFakeTimers()
+    timer.task = task
+    timer.start(1)
+    clock.tick(1)
+    timer.task = anotherTask
+    timer.start()
+    clock.tick(1)
+    clock.tick(1)
+    timer.end()
+    clock.restore()
+    expect(task).to.have.been.calledThrice
+    expect(anotherTask).to.not.have.been.called
+  })
+  it('should be restartable with restart', function () {
+    var task = this.sandbox.spy()
+    var anotherTask = this.sandbox.spy()
+    var timer = new Timer()
+    var clock = this.sandbox.useFakeTimers()
+    timer.task = task
+    timer.start(1)
+    clock.tick(1)
+    timer.task = anotherTask
+    timer.restart()
+    clock.tick(1)
+    clock.tick(1)
+    timer.end()
+    clock.restore()
+    expect(task).to.have.been.calledOnce
+    expect(anotherTask).to.have.been.calledTwice
+  })
+  it('should be stoppable with end', function () {
+    var task = this.sandbox.spy()
+    var timer = new Timer()
+    var clock = this.sandbox.useFakeTimers()
+    timer.task = task
+    timer.start(1)
+    clock.tick(1)
+    clock.tick(1)
+    timer.end()
+    clock.tick(1)
+    clock.restore()
+    expect(task).to.have.been.calledTwice
+  })
+})

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,8 @@ function Trace () {
     agent: this.agent,
     config: this.config
   })
+
+  this.agent.start()
 }
 
 Trace.prototype.report = function (name) {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -26,7 +26,8 @@ describe('The trace module', function () {
 
   it('initializes', function () {
     var fakeAgent = {
-      name: 'agent'
+      name: 'agent',
+      start: this.sandbox.spy()
     }
 
     var fakeConfig = {
@@ -48,6 +49,7 @@ describe('The trace module', function () {
       agent: fakeAgent,
       config: fakeConfig
     })
+    expect(fakeAgent.start).to.be.called
     expect(configCreateStub).to.be.calledOnce
   })
 })


### PR DESCRIPTION
Node v6.3.1 introduced a change the resulted in timers running on schedule. This change duplicated the number of expired timeout callbacks to be handled / iteration.
In our tests, timers with interval 0 were registered multiple times and never deregistered.
This overwhelmed the node process, that's why it crashed.

This PR introduces a change, so that timers have to be started explicitly. This means that in tests that don't rely on them, they won't be started at all.

resolves #114