### PR TITLE
Adds a Stop Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ trace.incrementMetric('user/signup')
 
 The name must have the following format: `<Category>/<Name>`
 
+### trace.stop()
+
+This method gracefully shutdown trace.
+
+```javascript
+trace.stop()
+```
+
+Note: There is no way to restart trace after calling this method. You should end your process after calling this
+method.
+
 ## Compatibility with Node versions
 
 * node v0.10@latest

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The name must have the following format: `<Category>/<Name>`
 
 ### trace.stop()
 
-This method gracefully shutdown trace.
+This method gracefully stops trace.
 
 ```javascript
 trace.stop()

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -7,7 +7,8 @@ var traceNoop = {
   report: function () {},
   reportError: function () {},
   getTransactionId: function () {},
-  sendMemorySnapshot: function () {}
+  sendMemorySnapshot: function () {},
+  stop : function () {}
 }
 
 function Trace (config) {
@@ -59,6 +60,10 @@ Trace.prototype.incrementMetric = function (name, amount) {
 Trace.prototype.recordMetric = function (name, value) {
   this._agent.customMetrics.record(name, value)
 }
+
+Trace.prototype.stop = function () {
+  this._agent._stopAll();
+};
 
 module.exports.Trace = Trace
 module.exports.noop = traceNoop


### PR DESCRIPTION
I have added a `trace.stop()` function that calls the `_agent._stopAll()`. I don't know if this is the best way to stop trace, but it works. I did not write a test. Sorry.