### PR TITLE
Fix: content-length header value

### DIFF
--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -79,7 +79,7 @@ CollectorApi.prototype._send = function (destinationUrl, data, callback) {
       'Content-Type': 'application/json',
       'X-Reporter-Version': libPackage.version,
       'X-Reporter-Language': this.collectorLanguage,
-      'Content-Length': payload.length
+      'Content-Length': Buffer.byteLength(payload)
     }
   }
 


### PR DESCRIPTION
This length is not the same as string length, since many characters require more bytes to encode. For example: 
```
var snowman = "☃";
snowman.length
// 1
Buffer.byteLength(snowman)
// 3
```