### PR TITLE
Improve proxy support

### DIFF
--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -275,6 +275,7 @@ CollectorApi.prototype.getService = function (cb) {
     port: opts.port,
     path: opts.path,
     method: 'POST',
+    agent: this.proxyAgent,
     headers: {
       'Authorization': 'Bearer ' + this.apiKey,
       'Content-Type': 'application/json',

--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -102,7 +102,7 @@ CollectorApi.prototype._send = function (destinationUrl, data, callback) {
   debug('sending data to trace servers: ', destinationUrl, payload)
 
   req.on('error', function (error) {
-    console.error('error: [trace]', 'There was an error connecting to the Trace servers. Make sure your servers can reach', opts.hostname)
+    console.error('error: [trace]', 'There was an error connecting to the Trace servers when sending data. Make sure your servers can reach', opts.hostname)
     debug('error connecting to the Trace servers', error)
     callback(error)
   })
@@ -323,7 +323,7 @@ CollectorApi.prototype.getService = function (cb) {
   debug('getting serviceKey with payload:', payload)
 
   req.on('error', function (error) {
-    console.error('error: [trace]', 'There was an error connecting to the Trace servers. Make sure your servers can reach', opts.hostname)
+    console.error('error: [trace]', 'There was an error connecting to the Trace servers to get the service key. Make sure your servers can reach', opts.hostname)
     debug('error connecting to the Trace servers', error)
   })
   req.write(payload)

--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -32,8 +32,9 @@ function CollectorApi (options) {
   this.baseRetryInterval = 1000 * 60 * 30 // 30 minutes
   this.serviceKey = null
 
-  if (options.proxy) {
-    this.proxyAgent = new HttpsProxyAgent(options.proxy)
+  var proxy = options.proxy || (process.env.https_proxy || process.env.HTTPS_PROXY)
+  if (proxy) {
+    this.proxyAgent = new HttpsProxyAgent(proxy)
   }
 }
 

--- a/lib/agent/api/index.spec.js
+++ b/lib/agent/api/index.spec.js
@@ -84,6 +84,17 @@ describe('The Trace CollectorApi module', function () {
     expect(collectorApi.proxyAgent).to.be.ok
   })
 
+  it('can use a proxy to get the service key', function () {
+    var httpsRequestSpy = this.sandbox.spy(https, 'request')
+    defaultConfig.proxy = 'http://127.0.0.1'
+
+    var collectorApi = CollectorApi.create(defaultConfig)
+
+    collectorApi.getService()
+    expect(httpsRequestSpy.firstCall.args[0].agent).to.eql(collectorApi.proxyAgent)
+    expect(collectorApi.proxyAgent).to.be.ok
+  })
+
   it('sends rpm metrics to the collector server', function () {
     var serviceKey = 12
 


### PR DESCRIPTION
Firstly fixes an issue that the `getService` function doesn't use the proxy setting, causing an connection error when using Trace behind a proxy.

Secondly, improved proxy handling to first use the TRACE_PROXY setting from config if present, but if not present fall back to the system environment variable HTTPS_PROXY. This avoids having to set different values in `trace.config.js`, as its already configured on the system.

Thirdly, changed the two identical error messages to give better information and help identify the failing area easier.