### PR TITLE
Fix windows childProcess error (spawn npm ENOENT)

### DIFF
--- a/lib/agent/security/security.js
+++ b/lib/agent/security/security.js
@@ -112,7 +112,7 @@ Security.prototype.collectSnykFlags = function collectSnykFlags (callback) {
 
 Security.prototype.collectDependencies = function collectDependencies (callback) {
   var maxBuffer = 10 * 1024 * 1024 // 10mb
-  childProcess.execFile('npm', ['ls', '--json', '--production'], {
+  childProcess.execFile(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['ls', '--json', '--production'], {
     maxBuffer: maxBuffer
   }, function (error, stdout, stderr) {
     if (error) {


### PR DESCRIPTION
Fix issue of calling npm on windows host.

More information on [NodeJS Archive](https://github.com/nodejs/node-v0.x-archive/issues/5841).