### PR TITLE
fix: vulnerability in qs reported by this lib 😄

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "lodash.uniq": "4.5.0",
     "lodash.remove": "4.7.0",
     "lodash.some": "4.6.0",
-    "qs": "6.3.2",
     "semver": "5.3.0",
     "sync-request": "3.0.1",
     "uuid": "3.0.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash.uniq": "4.5.0",
     "lodash.remove": "4.7.0",
     "lodash.some": "4.6.0",
-    "qs": "6.3.1",
+    "qs": "6.3.2",
     "semver": "5.3.0",
     "sync-request": "3.0.1",
     "uuid": "3.0.1"


### PR DESCRIPTION
The library qs has vulnerabilities at version 6.3.1. An updated version of qs (~6.3.2) does not have the vulnerability.