### PR TITLE
Avoid Webpack2 build error

### DIFF
--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -12,7 +12,7 @@ var stringify = require('json-stringify-safe')
 var BufferStream = require('./bufferStream')
 
 var bl = require('bl')
-var libPackage = require('../../../package')
+var libPackage = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../package.json')).toString())
 var zlib = require('zlib')
 
 function CollectorApi (options) {

--- a/lib/agent/api/index.js
+++ b/lib/agent/api/index.js
@@ -10,6 +10,8 @@ var assign = require('lodash.assign')
 var HttpsProxyAgent = require('https-proxy-agent')
 var stringify = require('json-stringify-safe')
 var BufferStream = require('./bufferStream')
+var fs = require('fs')
+var path = require('path')
 
 var bl = require('bl')
 var libPackage = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../package.json')).toString())


### PR DESCRIPTION
In TypeScript, build typescript code for distribution. At this time, error caused from path. This solution can avoid path problem, but webpack2 option node.__dirname flag set true.
